### PR TITLE
Add support for specifying the local bind address for each connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,15 @@ We ask you to fill the form with the following fields:
 
 **Alias** - alternative name of the resource that will be displayed on the homepage(optional)
 
-**Port Forwarding** - Fill two fields. Local port - port from your local machine where the resource will be forwarded. Resource port - port of the resource from the Kubernetes cluster 
+**Port Forwarding** 
+ 
+- **Local Address** - Local address to listen on.  Putting each service on its own address avoids
+  sharing/collisions between services on cookies and port number.  Specify a loopback address like 
+  `127.0.x.x` or add entries to your hosts file like `127.0.1.1 dashboard.production.kbf` and put the assigned 
+  name in this column.  If blank, `localhost` / `127.0.0.1` will be used.
+- **Local port** - port from your local machine where the resource will be forwarded.  Note that ports <= 1024 are
+  restricted to user `root`
+- **Resource port** - port of the resource from the Kubernetes cluster 
 
 <a target="_blank" href="https://user-images.githubusercontent.com/2697570/60754738-e207cd00-9fe5-11e9-95b3-8f4704ca3dce.png"><img width="320" alt="Port Forwarding Form" src="https://user-images.githubusercontent.com/2697570/60754738-e207cd00-9fe5-11e9-95b3-8f4704ca3dce.png"></a>
 

--- a/cypress/factories/state.js
+++ b/cypress/factories/state.js
@@ -33,7 +33,7 @@ export function buildService(overrides = {}, bCluster = buildCluster) {
     workloadType: 'pod',
     workloadName: 'workloadName',
     forwards: [
-      { id: generateForwardId(), localPort: 3000, remotePort: 4000 }
+      { id: generateForwardId(), localAddress: '', localPort: 3000, remotePort: 4000 }
     ],
     ...overrides
   }

--- a/src/renderer/components/shared/service/ForwardsTable.vue
+++ b/src/renderer/components/shared/service/ForwardsTable.vue
@@ -2,6 +2,9 @@
   <table class="table forwards-table">
     <tbody>
       <tr>
+        <td class="forwards-table__column-header forwards-table__column-header_name_local-address">
+          Local Address
+        </td>
         <td class="forwards-table__column-header forwards-table__column-header_name_local-port">
           Local Port
           <IconArrowDropdown thin to="right" class="forwards-table__arrow-column-divider" />
@@ -14,6 +17,15 @@
         :key="forwardAttribute.$model.id"
         class="forwards-table__column"
       >
+        <td class="forwards-table__column forwards-table__column_name_local-address">
+          <BaseInput
+            v-model.number="forwardAttribute.localAddress.$model"
+            inline
+            type="string"
+            size="s"
+            :invalid="forwardAttribute.localAddress.$error"
+          />
+        </td>
         <td class="forwards-table__column forwards-table__column_name_local-port">
           <BaseInput
             v-model.number="forwardAttribute.localPort.$model"
@@ -40,6 +52,15 @@
       </tr>
 
       <tr :key="newForward.id">
+        <td class="forwards-table__column forwards-table__column_name_local-address">
+          <BaseInput
+            v-model.number="newForward.localAddress"
+            inline
+            type="string"
+            size="s"
+            @blur="create"
+          />
+        </td>
         <td class="forwards-table__column forwards-table__column_name_local-port">
           <BaseInput
             v-model.number="newForward.localPort"
@@ -83,7 +104,7 @@ export default {
     event: 'change'
   },
   props: {
-    value: { type: Array, default: () => [] }, // [{ localPort: 123, remotePort: 345, id: <uuid> }]
+    value: { type: Array, default: () => [] }, // [{ localAddress: '', localPort: 123, remotePort: 345, id: <uuid> }]
     attribute: { type: Object, default: null }
   },
   data() {
@@ -105,7 +126,7 @@ export default {
   },
   methods: {
     getEmptyForward() {
-      return { localPort: null, remotePort: null, id: uuidv1() }
+      return { localAddress: '', localPort: null, remotePort: null, id: uuidv1() }
     },
     create() {
       if (this.newForward.remotePort || this.newForward.localPort) {
@@ -129,6 +150,12 @@ export default {
 .forwards-table {
   .forwards-table__column {
     text-align: center;
+  }
+
+  .forwards-table__column-header_name_local-address {
+    border-right: none;
+    width: 341px;
+    position: relative;
   }
 
   .forwards-table__column-header_name_local-port {

--- a/src/renderer/components/shared/service/ServiceForm.vue
+++ b/src/renderer/components/shared/service/ServiceForm.vue
@@ -100,6 +100,7 @@ export default {
         required,
         minLength: minLength(1),
         $each: {
+          localAddress: { type: String, default: '' },
           localPort: { required, integer, between: between(0, 65535) },
           remotePort: { required, integer, between: between(0, 65535) }
         }

--- a/src/renderer/store/modules/Services.js
+++ b/src/renderer/store/modules/Services.js
@@ -34,6 +34,7 @@ export const serviceSchema = {
         required: ['id', 'localPort', 'remotePort'],
         properties: {
           id: { type: 'string' },
+          localAddress: { type: 'string' },
           localPort: { type: 'integer', minimum: 0, maximum: 65535 },
           remotePort: { type: 'integer', minimum: 0, maximum: 65535 }
         }


### PR DESCRIPTION
Putting each service on its own address avoids sharing/collisions
between services on cookies and port number.  Specify a loopback address
like `127.0.x.x` or add entries to your hosts file like `127.0.1.1
dashboard.production.kbf` and use the assigned name.

Fixes https://github.com/pixel-point/kube-forwarder/issues/37
