### PR TITLE
Add support for specifying the local bind address for each resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,17 @@ We ask you to fill the form with the following fields:
 
 **Alias** - alternative name of the resource that will be displayed on the homepage(optional)
 
-**Port Forwarding** - Fill two fields. Local port - port from your local machine where the resource will be forwarded. Resource port - port of the resource from the Kubernetes cluster 
+**Port Forwarding** 
+ 
+- **Local port** - port from your local machine where the resource will be forwarded.  Note that ports <= 1024 are
+  restricted to user `root`
+- **Resource port** - port of the resource from the Kubernetes cluster 
+
+**Use Custom Local Address** - Check this and put an IP address or hostname into the text field to
+use a different listen address. Putting each service on its own address avoids sharing/collisions between 
+services on cookies and port number.  Specify a loopback address like `127.0.x.x` or add entries to your 
+hosts file like `127.0.1.1 dashboard.production.kbf` and put the assigned name in this column.  If blank or
+unchecked, `localhost` / `127.0.0.1` will be used.
 
 <a target="_blank" href="https://user-images.githubusercontent.com/2697570/60754738-e207cd00-9fe5-11e9-95b3-8f4704ca3dce.png"><img width="320" alt="Port Forwarding Form" src="https://user-images.githubusercontent.com/2697570/60754738-e207cd00-9fe5-11e9-95b3-8f4704ca3dce.png"></a>
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -13,7 +13,7 @@
   <body>
     <div id="app"></div>
     <!-- Set `__static` path to static files in production -->
-    <% if (!process.browser) { %>
+    <% if (!(typeof process === 'object' && process.browser)) { %>
       <script>
         if (process.env.NODE_ENV !== 'development') window.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
       </script>

--- a/src/renderer/components/Clusters/ServiceItem.vue
+++ b/src/renderer/components/Clusters/ServiceItem.vue
@@ -8,6 +8,8 @@
       <div class="service-item__title">{{ getServiceLabel(service) }}</div>
       <div class="service-item__description">
         <span>From <span class="service-item__namespace">{{ service.namespace }}</span> namespace exposed to</span>
+        <span v-if="service.localAddress" class="service-item__address">{{ service.localAddress }}</span>
+        <span>port{{ forwards.length > 1 ? 's' : '' }}</span>
         <span class="service-item__ports">
           <span v-for="(forward, index) in forwards" :key="forward.id" class="service-item__port">
             <a
@@ -22,7 +24,6 @@
             />
           </span>
         </span>
-        <span>port{{ forwards.length > 1 ? 's' : '' }}</span>
       </div>
     </div>
 
@@ -92,7 +93,10 @@ export default {
       return this.service.forwards
     },
     portStates() {
-      return this.forwards.map(forward => this.$store.state.Connections[forward.localPort] || {})
+      return this.forwards.map(
+        forward =>
+          this.$store.state.Connections[[this.service.localAddress || 'localhost', forward.localPort].join(':')] || {}
+      )
     },
     portHttp() {
       const result = {}
@@ -177,7 +181,7 @@ export default {
     },
     openHttpPort(e, port) {
       e.preventDefault()
-      electron.shell.openExternal(`http://localhost:${port}`)
+      electron.shell.openExternal(`http://${this.service.localAddress || 'localhost'}:${port}`)
     }
   }
 }
@@ -227,7 +231,7 @@ export default {
   color: $color-text-tertiary;
 }
 
-.service-item__port-number {
+.service-item__port-number, .service-item__address {
   color: $color-text;
   font-weight: 500;
 

--- a/src/renderer/components/shared/service/ServiceForm.vue
+++ b/src/renderer/components/shared/service/ServiceForm.vue
@@ -42,6 +42,20 @@
       <ControlGroup label="Ports Forwarding">
         <ForwardsTable v-model="attributes.forwards" :attribute="$v.attributes.forwards" />
       </ControlGroup>
+
+      <ControlGroup label="">
+        <BaseCheckbox :value="attributes.localAddress != null"
+                      @input="toggleCustomLocalAddress"
+        >
+          Use custom local address
+        </BaseCheckbox>
+      </ControlGroup>
+
+      <ControlGroup v-if="attributes.localAddress != null" label="">
+        <BaseInput v-model="$v.attributes.localAddress.$model"
+                   placeholder="localhost"
+        />
+      </ControlGroup>
     </fieldset>
 
     <div class="control-actions">
@@ -63,6 +77,7 @@ import { CoreV1Api, ExtensionsV1beta1Api } from '@kubernetes/client-node' // esl
 import * as resourceKinds from '../../../lib/constants/workload-types'
 import * as clusterHelper from '../../../lib/helpers/cluster'
 
+import BaseCheckbox from '../form/BaseCheckbox'
 import BaseForm from '../form/BaseForm'
 import BaseInput from '../form/BaseInput'
 import BaseSelect from '../form/BaseSelect'
@@ -74,6 +89,7 @@ import AutocompleteInput from '../form/AutocompleteInput'
 export default {
   components: {
     AutocompleteInput,
+    BaseCheckbox,
     ControlGroup,
     BaseInput,
     BaseForm,
@@ -103,7 +119,8 @@ export default {
           localPort: { required, integer, between: between(0, 65535) },
           remotePort: { required, integer, between: between(0, 65535) }
         }
-      }
+      },
+      localAddress: {}
     }
   },
   data() {
@@ -168,7 +185,8 @@ export default {
         namespace: '',
         workloadType: null,
         workloadName: '',
-        forwards: []
+        forwards: [],
+        localAddress: null
       }
     },
     async handleNamespaceFocus() {
@@ -229,6 +247,9 @@ export default {
           this.error = JSON.stringify(result.errors)
         }
       })
+    },
+    toggleCustomLocalAddress() {
+      this.attributes.localAddress = this.attributes.localAddress == null ? '' : null
     }
   }
 }

--- a/src/renderer/store/modules/Services.js
+++ b/src/renderer/store/modules/Services.js
@@ -38,7 +38,8 @@ export const serviceSchema = {
           remotePort: { type: 'integer', minimum: 0, maximum: 65535 }
         }
       }
-    }
+    },
+    localAddress: { type: 'string' }
   }
 }
 const { validate, pick } = createToolset(serviceSchema)


### PR DESCRIPTION
Putting each service on its own address avoids sharing/collisions
between services on cookies and port number.  Specifically this lets me put staging kubernetes dashboard on `127.0.0.1` and production on `localhost` so that they don't overwrite each others' cookies.
