### PR TITLE
Change Help link to kube-forwarder site

### DIFF
--- a/src/main/menuTemplate.js
+++ b/src/main/menuTemplate.js
@@ -43,7 +43,7 @@ export default function buildMenuTemplate(app) {
         {
           label: 'Learn More',
           click() {
-            require('electron').shell.openExternal('https://electronjs.org')
+            require('electron').shell.openExternal('https://kube-forwarder.pixelpoint.io/')
           }
         }
       ]


### PR DESCRIPTION
The help menu is currently redirecting to https://electronjs.org with this fix the help link is pointing to https://kube-forwarder.pixelpoint.io

BUG:
https://github.com/pixel-point/kube-forwarder/issues/32