### PR TITLE
Check if process is defined before checking process.browser

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -13,7 +13,7 @@
   <body>
     <div id="app"></div>
     <!-- Set `__static` path to static files in production -->
-    <% if (!process.browser) { %>
+    <% if (!(typeof process === 'object' && process.browser)) { %>
       <script>
         if (process.env.NODE_ENV !== 'development') window.__static = require('path').join(__dirname, '/static').replace(/\\/g, '\\\\')
       </script>


### PR DESCRIPTION
When I ran the app in development I was getting an error "process is not defined" here.

Why this happens to me and not the core developers (I assume) remains a mystery, but the fix seems simple enough.