### PR TITLE
Fix the race condition during create initial connection

### DIFF
--- a/src/renderer/lib/k8s-port-forwarding-patch.js
+++ b/src/renderer/lib/k8s-port-forwarding-patch.js
@@ -52,7 +52,13 @@ WebSocketHandler.restartableHandleStandardInput = async function (createWS, stdi
 
   // It's important to open connection immediately (even without data) for some apps (for example: mariadb)
   try {
-    ws = await createWS()
+    let initialWS = await createWS()
+    if (!ws) {
+      ws = initialWS
+    } else {
+      // Connection has already been created in processData, so it should not be overwritten.
+      initialWS.close()
+    }
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
I think that this PR is likely to resolve issue #63.

Below is an example sequence to describe the problem fixed by the PR.

1. Execute `await createWS` at https://github.com/pixel-point/kube-forwarder/blob/c62fe441d9e994828efe544b6be6ba34d01ad40d/src/renderer/lib/k8s-port-forwarding-patch.js#L55 and wait for it to finish.
2. `processData` is called, `ws` is created at https://github.com/pixel-point/kube-forwarder/blob/c62fe441d9e994828efe544b6be6ba34d01ad40d/src/renderer/lib/k8s-port-forwarding-patch.js#L29 and sent data using `ws`.
3. `await createWS` is finished, `ws` is overwritten to a new connection.
4. `processData` is called again, the data is sent using the new `ws`.

I don't know the specific reason, but sending data from a different WS along the way seems to cause TLS issues.
