### PR TITLE
Add option to start and stop all services

### DIFF
--- a/src/renderer/components/Clusters.vue
+++ b/src/renderer/components/Clusters.vue
@@ -20,6 +20,8 @@
                   <Action @click="unfoldAll(slotProps.close)">Show All Clusters</Action>
                 </li>
                 <li v-else><Action @click="foldAll(slotProps.close)">Collapse All Clusters</Action></li>
+                <li><Action @click="startAll">Start all</Action></li>
+                <li><Action @click="stopAll">Stop all</Action></li>
               </ul>
             </template>
           </Dropdown>
@@ -145,7 +147,19 @@ export default {
       this.clustersToRender.forEach(cluster => {
         this.updateCluster({ id: cluster.id, folded })
       })
-    }
+    },
+    startAll() {
+      const services = Object.values(this.$store.state.Services.items)
+      services.forEach(service => {
+        this.$store.dispatch('Connections/createConnection', service)
+      })
+    },
+    stopAll() {
+      const services = Object.values(this.$store.state.Services.items)
+      services.forEach(service => {
+        this.$store.dispatch('Connections/deleteConnection', service)
+      })
+    },
   }
 }
 </script>

--- a/src/renderer/components/Clusters/ClusterItem.vue
+++ b/src/renderer/components/Clusters/ClusterItem.vue
@@ -16,6 +16,8 @@
           <li><Action :to="createServicePath">Add a Resource</Action></li>
           <li><Action :to="editPath">Edit</Action></li>
           <li><Action @click="exportCluster">Export</Action></li>
+          <li><Action @click="startAll">Start all</Action></li>
+          <li><Action @click="stopAll">Stop all</Action></li>
           <li><Action @click="handleFold">Collapse</Action></li>
           <li><Action theme="danger" @click="handleDelete">Delete</Action></li>
         </ul>
@@ -130,6 +132,16 @@ export default {
           }
         }
       }
+    },
+    startAll() {
+      this.services.forEach(service => {
+        this.$store.dispatch('Connections/createConnection', service)
+      })
+    },
+    stopAll() {
+      this.services.forEach(service => {
+        this.$store.dispatch('Connections/deleteConnection', service)
+      })
     }
   }
 }


### PR DESCRIPTION
Adds options to start and stop all services for a specific cluster or over all clusters. I am no expert (as you can see ;) ) with JavaScript or Vue, so obviously things can be done better... 
Fixes #48 