### PR TITLE
docs: update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Kube Forwarder allows you export cluster configuration in JSON that you could us
 ### Install with Homebrew
 
 ```
-brew cask install kube-forwarder
+brew install --cask kube-forwarder
 ```
 
 ## Contributing


### PR DESCRIPTION
The latest brew way to install is `brew install --cask kube-forwarder`.
BTW, thanks for this awesome tool! 😃