### PR TITLE
Updated brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Kube Forwarder allows you export cluster configuration in JSON that you could us
 ### Install with Homebrew
 
 ```
-brew cask install kube-forwarder
+brew install --cask kube-forwarder
 ```
 
 ## Contributing


### PR DESCRIPTION
```
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```